### PR TITLE
Global rename of `server_url` to `base_url`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,11 +4,11 @@ layout: page
 
 # API reference
 
-The API reference topics refer to the To-Do Service's server URL as `{server_url}`.
-Replace the `{server_url}` with the address of the server that hosts your To-Do Service
+The API reference topics refer to the To-Do Service's base URL as `{base_url}`.
+Replace `{base_url}` with the address of the server that hosts your To-Do Service
 API for the correct URL.
 
-On test and development installations, the server address is typically `http://localhost:3000`.
+On test and development installations, the server's base address is typically `http://localhost:3000`.
 
 ## Resources
 

--- a/docs/api/task.md
+++ b/docs/api/task.md
@@ -8,7 +8,7 @@ Base endpoint:
 
 ```shell
 
-{server_url}/tasks
+{base_url}/tasks
 ```
 
 Contains information about tasks stored for the users of the service.

--- a/docs/api/tasks-get-all-tasks-nikki-everett.md
+++ b/docs/api/tasks-get-all-tasks-nikki-everett.md
@@ -10,7 +10,7 @@ Returns an array of [`task`](task.md) objects that contains all tasks that users
 
 ```shell
 
-{server_url}/tasks
+{base_url}/tasks
 ```
 
 ## Params

--- a/docs/api/tasks-get-by-task-id_alkreb.md
+++ b/docs/api/tasks-get-by-task-id_alkreb.md
@@ -4,7 +4,7 @@ layout: page
 
 # Get task by ID
 
-GET {server_url}/task/{id}
+GET {base_url}/task/{id}
 
 Retrieves a task by the task id.
 

--- a/docs/api/tasks-get-by-task-id_csun.md
+++ b/docs/api/tasks-get-by-task-id_csun.md
@@ -9,7 +9,7 @@ Returns a [`task`](task.md) array that contains only the task resource specified
 ## URL
 
 ```shell
-{server_url}/tasks/{id}
+{base_url}/tasks/{id}
 ```
 
 ## Params

--- a/docs/api/tasks-get-tasks-levibeverly.md
+++ b/docs/api/tasks-get-tasks-levibeverly.md
@@ -7,7 +7,7 @@ layout: page
 ## Base endpoint
 
 ```shell
-{server_url}/tasks
+{base_url}/tasks
 ```
 
 ## Description

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -8,7 +8,7 @@ Base endpoint:
 
 ```shell
 
-{server_url}/users
+{base_url}/users
 ```
 
 Contains information about the users of the service.

--- a/docs/api/users-get-all-users.md
+++ b/docs/api/users-get-all-users.md
@@ -10,7 +10,7 @@ Returns an array of [`user`](user.md) objects that contains all users that have 
 
 ```shell
 
-{server_url}/users
+{base_url}/users
 ```
 
 ## Params

--- a/docs/api/users-get-user-by-id-CT.md
+++ b/docs/api/users-get-user-by-id-CT.md
@@ -10,7 +10,7 @@ Returns an array of  [`task`](task.md) objects that relate to the user specified
 
 ```shell
 
-{server_url}/tasks?user_id={user_id}
+{base_url}/tasks?user_id={user_id}
 ```
 
 ## Params

--- a/docs/api/users-get-user-by-id.md
+++ b/docs/api/users-get-user-by-id.md
@@ -10,7 +10,7 @@ Returns an array of  [`user`](user.md) objects that contains only the user speci
 
 ```shell
 
-{server_url}/users/{id}
+{base_url}/users/{id}
 ```
 
 ## Params

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ After your system is ready, [tutorials](./tutorials.md) such as these show you h
 
 Detailed descriptions of the service's resources.
 
-The API reference docs refer to a `{base_url}` when they
+The [API reference docs](api.md) refer to a `{base_url}` when they
 refer to the URL of a resource. The `{base_url}` value depends
 on the installation of the service.
 


### PR DESCRIPTION
This is to standardize the substitution string used to generically refer to the URL of the server hosting the To-Do service in the documentation and Postman collections.
Also includes adding a link to API reference title page in the landing page.