### PR TITLE
Fix incorrect use of `server_url` substitution string

### DIFF
--- a/docs/api/tasks-get-all-tasks_chood.md
+++ b/docs/api/tasks-get-all-tasks_chood.md
@@ -10,7 +10,7 @@ This method returns an array of [`task`](task.md) objects that contain all tasks
 
 ```shell
 
-{server_url}/tasks
+{base_url}/tasks
 ```
 
 ## Params

--- a/docs/api/tasks-get-by-task-id_dmanis.md
+++ b/docs/api/tasks-get-by-task-id_dmanis.md
@@ -8,7 +8,7 @@ The Get Task service fetches the details for a given task in the system.
 
 ## URL
 
-{server_url}/tasks/{id}
+{base_url}/tasks/{id}
 
 ## HTTP method
 


### PR DESCRIPTION
This PR fixes some incorrect substitution strings that slipped through the editing process.